### PR TITLE
Support for slf4j-jdk-platform-logging with GraalVM (build time initialization)

### DIFF
--- a/avaje-simple-logger/pom.xml
+++ b/avaje-simple-logger/pom.xml
@@ -44,6 +44,12 @@
       <artifactId>avaje-config</artifactId>
       <version>4.2</version>
     </dependency>
+    <dependency>
+      <groupId>org.graalvm.nativeimage</groupId>
+      <artifactId>svm</artifactId>
+      <version>25.0.1</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>

--- a/avaje-simple-logger/src/main/java/io/avaje/simplelogger/graalvm/BuildInitialization.java
+++ b/avaje-simple-logger/src/main/java/io/avaje/simplelogger/graalvm/BuildInitialization.java
@@ -1,0 +1,53 @@
+package io.avaje.simplelogger.graalvm;
+
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
+
+/**
+ * GraalVM Native Image build Feature that initialises Simple Logger classes at Build time.
+ * <p>
+ * Use this when using slf4j-jdk-platform-logging to redirect System.Logger to slf4j. This
+ * is needed as GraalVM by default initialised JDK logging at build time. Adding this
+ * feature supports redirecting System.Logger to avaje simple logger by also initialising
+ * the avaje simple logger classes at build time.
+ * </p>
+ */
+public class BuildInitialization implements Feature {
+
+  @Override
+  public void beforeAnalysis(BeforeAnalysisAccess access) {
+
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.FilterBuilder$PatternFilter"));
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.FilterBuilder$ReflectiveInvocation"));
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.FilterBuilder$SpringFilter"));
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.FilterBuilder$Generated"));
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.FilterBuilder$Group"));
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.FilterBuilder$JDKInternals"));
+
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.StackElementFilter"));
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.AbbreviatorByLength"));
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.AbbreviatorCaching"));
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.StackHasher"));
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.ThrowableConverter"));
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.JsonEncoder"));
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.JsonWriter"));
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.SimpleLogger"));
+
+
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.json.stream.core.JsonNames"));
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.json.stream.core.CoreJsonStream"));
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.json.stream.core.HybridBufferRecycler$XorShiftThreadProbe"));
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.json.stream.core.HybridBufferRecycler"));
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.json.stream.core.HybridBufferRecycler$StripedLockFreePool"));
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.json.stream.core.Recyclers$ThreadLocalPool"));
+
+    // check for optional SLF4JPlatformLogger
+    Class<?> slfPlatform = access.findClassByName("org.slf4j.jdk.platform.logging.SLF4JPlatformLogger");
+    if (slfPlatform != null) {
+      RuntimeClassInitialization.initializeAtBuildTime(slfPlatform);
+      RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("org.slf4j.jdk.platform.logging.SLF4JPlatformLoggerFactory"));
+      RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("org.slf4j.jdk.platform.logging.SLF4JSystemLoggerFinder"));
+    }
+  }
+
+}

--- a/avaje-simple-logger/src/main/java/module-info.java
+++ b/avaje-simple-logger/src/main/java/module-info.java
@@ -8,6 +8,7 @@ module io.avaje.simplelogger.dynamic {
   requires transitive io.avaje.simplelogger;
   requires transitive io.avaje.config;
   requires io.avaje.applog;
+  requires static org.graalvm.nativeimage;
 
   provides io.avaje.config.ConfigExtension with DynamicLogLevels;
 }

--- a/avaje-simple-logger/src/main/resources/META-INF/native-image/io.avaje.simplelogger-extension/native-image.properties
+++ b/avaje-simple-logger/src/main/resources/META-INF/native-image/io.avaje.simplelogger-extension/native-image.properties
@@ -1,0 +1,2 @@
+Args=--no-fallback \
+      --features=io.avaje.simplelogger.graalvm.BuildInitialization


### PR DESCRIPTION
Will do build time initialization of avaje simple logger classes with graalvm native image, and thus support the use of slf4j-jdk-platform-logging.

This is required due to graalvm native-image wanting to initialise jdk logging at build time (which is a bit viral and means the logger implementation needs to support build time initialisation as well).