### PR TITLE
Add OTEL trace_id and span_id support (for graalvm native image)

### DIFF
--- a/avaje-simple-json-logger/pom.xml
+++ b/avaje-simple-json-logger/pom.xml
@@ -32,6 +32,13 @@
     </dependency>
 
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <version>1.48.0</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <type>test-jar</type>

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonEncoder.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonEncoder.java
@@ -19,6 +19,7 @@ final class JsonEncoder {
   private final StackHasher stackHasher;
   private final ThrowableConverter throwableConverter;
   private final DateTimeFormatter formatter;
+  private final TraceContext traceContext;
   private final int fieldExtra;
   private final String component;
   private final String environment;
@@ -33,7 +34,8 @@ final class JsonEncoder {
         DateTimeFormatter formatter,
         boolean includeStackHash,
         Map<String, String> customFieldsMap,
-        ThrowableConverter throwableConverter) {
+        ThrowableConverter throwableConverter,
+        TraceContext traceContext) {
 
     this.json = json;
     this.properties = this.json.properties(propertyNames);
@@ -44,6 +46,7 @@ final class JsonEncoder {
     this.includeStackHash = includeStackHash;
     this.customFieldsMap = customFieldsMap;
     this.throwableConverter = throwableConverter;
+    this.traceContext = traceContext;
     this.fieldExtra = this.customFieldsMap.entrySet().stream()
       .mapToInt(e -> e.getKey().length() + e.getValue().length() + 6)
       .sum();
@@ -82,6 +85,16 @@ final class JsonEncoder {
       writer.value(message);
       writer.name(6);
       writer.value(threadName);
+      String traceId = traceContext.traceId();
+      if (traceId != null) {
+        writer.name(11);
+        writer.value(traceId);
+      }
+      String spanId = traceContext.spanId();
+      if (spanId != null) {
+        writer.name(12);
+        writer.value(spanId);
+      }
       if (!stackTraceBody.isEmpty()) {
         writer.name(7);
         writer.value(t.getClass().getName());
@@ -102,8 +115,10 @@ final class JsonEncoder {
       Map<String, String> contextMap = MDC.getCopyOfContextMap();
       if (contextMap != null) {
         contextMap.forEach((k, v) -> {
-          writer.name(k);
-          writer.value(v);
+          if (!"trace_id".equals(k) && !"span_id".equals(k)) {
+            writer.name(k);
+            writer.value(v);
+          }
         });
       }
       writer.endObject();

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonEncoderBuilder.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonEncoderBuilder.java
@@ -111,16 +111,27 @@ final class JsonEncoderBuilder {
     String[] keys = basePropertyNames(naming);
     String[] mappedPropertyNames = toPropertyNames(keys, propertyNames);
     final DateTimeFormatter formatter = TimeZoneUtils.jsonFormatter(timestampPattern, timeZone.toZoneId());
-    return new JsonEncoder(mappedPropertyNames, json, component, environment, stackHasher, formatter, includeStackHash, customFieldsMap, throwableConverter);
+    final TraceContext traceContext = initTraceContext();
+    return new JsonEncoder(mappedPropertyNames, json, component, environment, stackHasher, formatter, includeStackHash, customFieldsMap, throwableConverter, traceContext);
+  }
+
+  private static TraceContext initTraceContext() {
+    try {
+      Class.forName("io.opentelemetry.api.trace.Span");
+      return (TraceContext) Class.forName("io.avaje.simplelogger.encoder.OtelTraceContext")
+        .getDeclaredConstructor().newInstance();
+    } catch (Exception e) {
+      return new NoopTraceContext();
+    }
   }
 
   static String[] basePropertyNames(String naming) {
     if ("underscore".equals(naming)) {
-      return new String[]{"component", "env", "timestamp", "level", "logger_name", "message", "thread", "exception_type", "exception_message", "exception_stackhash", "exception_stacktrace"};
+      return new String[]{"component", "env", "timestamp", "level", "logger_name", "message", "thread", "exception_type", "exception_message", "exception_stackhash", "exception_stacktrace", "trace_id", "span_id"};
     } else if ("camel".equals(naming)) {
-      return new String[]{"component", "env", "timestamp", "level", "loggerName", "message", "thread", "exceptionType", "exceptionMessage", "exceptionStackhash", "exceptionStacktrace"};
+      return new String[]{"component", "env", "timestamp", "level", "loggerName", "message", "thread", "exceptionType", "exceptionMessage", "exceptionStackhash", "exceptionStacktrace", "traceId", "spanId"};
     } else {
-      return new String[]{"component", "env", "timestamp", "level", "logger", "message", "thread", "exceptionType", "exceptionMessage", "stackhash", "stacktrace"};
+      return new String[]{"component", "env", "timestamp", "level", "logger", "message", "thread", "exceptionType", "exceptionMessage", "stackhash", "stacktrace", "trace_id", "span_id"};
     }
   }
 

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/NoopTraceContext.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/NoopTraceContext.java
@@ -1,0 +1,17 @@
+package io.avaje.simplelogger.encoder;
+
+/**
+ * No-op TraceContext used when OpenTelemetry API is not on the classpath.
+ */
+final class NoopTraceContext implements TraceContext {
+
+  @Override
+  public String traceId() {
+    return null;
+  }
+
+  @Override
+  public String spanId() {
+    return null;
+  }
+}

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/OtelTraceContext.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/OtelTraceContext.java
@@ -1,0 +1,27 @@
+package io.avaje.simplelogger.encoder;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+
+/**
+ * TraceContext implementation that reads from the OpenTelemetry API.
+ */
+final class OtelTraceContext implements TraceContext {
+
+  @Override
+  public String traceId() {
+    SpanContext ctx = spanContext();
+    return ctx != null ? ctx.getTraceId() : null;
+  }
+
+  @Override
+  public String spanId() {
+    SpanContext ctx = spanContext();
+    return ctx != null ? ctx.getSpanId() : null;
+  }
+
+  private static SpanContext spanContext() {
+    SpanContext ctx = Span.current().getSpanContext();
+    return ctx.isValid() ? ctx : null;
+  }
+}

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/TraceContext.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/TraceContext.java
@@ -1,0 +1,17 @@
+package io.avaje.simplelogger.encoder;
+
+/**
+ * Provides trace context (trace_id and span_id) for structured log output.
+ */
+interface TraceContext {
+
+  /**
+   * Return the current trace ID, or null if not available.
+   */
+  String traceId();
+
+  /**
+   * Return the current span ID, or null if not available.
+   */
+  String spanId();
+}

--- a/avaje-simple-json-logger/src/main/java/module-info.java
+++ b/avaje-simple-json-logger/src/main/java/module-info.java
@@ -5,6 +5,7 @@ module io.avaje.simplelogger {
 
   requires transitive org.slf4j;
   requires transitive io.avaje.json;
+  requires static io.opentelemetry.api;
   provides org.slf4j.spi.SLF4JServiceProvider with SimpleLoggerProvider;
   opens io.avaje.simplelogger to org.slf4j;
 }

--- a/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/JsonEncoderBuilderTest.java
+++ b/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/JsonEncoderBuilderTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JsonEncoderBuilderTest {
 
-  String[] baseKeys = {"component", "env", "timestamp", "level", "logger", "message", "thread", "exceptionType", "exceptionMessage", "stackhash", "stacktrace"};
+  String[] baseKeys = {"component", "env", "timestamp", "level", "logger", "message", "thread", "exceptionType", "exceptionMessage", "stackhash", "stacktrace", "trace_id", "span_id"};
 
   @Test
   void toPropertyNames_when_null() {
@@ -21,32 +21,32 @@ class JsonEncoderBuilderTest {
   void toPropertyNames_several() {
     String[] originalKeys = JsonEncoderBuilder.basePropertyNames(null);
     String[] names = JsonEncoderBuilder.toPropertyNames(originalKeys,"component = c; env=e,thread=_foo ,exceptionType=exType ");
-    assertThat(names).isEqualTo(new String[]{"c", "e", "timestamp", "level", "logger", "message", "_foo", "exType", "exceptionMessage", "stackhash", "stacktrace"});
+    assertThat(names).isEqualTo(new String[]{"c", "e", "timestamp", "level", "logger", "message", "_foo", "exType", "exceptionMessage", "stackhash", "stacktrace", "trace_id", "span_id"});
   }
 
   @Test
   void toPropertyNames_onlyOne() {
     String[] originalKeys = JsonEncoderBuilder.basePropertyNames(null);
     String[] names = JsonEncoderBuilder.toPropertyNames(originalKeys, "logger=loggerName");
-    assertThat(names).isEqualTo(new String[]{"component", "env", "timestamp", "level", "loggerName", "message", "thread", "exceptionType", "exceptionMessage", "stackhash", "stacktrace"});
+    assertThat(names).isEqualTo(new String[]{"component", "env", "timestamp", "level", "loggerName", "message", "thread", "exceptionType", "exceptionMessage", "stackhash", "stacktrace", "trace_id", "span_id"});
   }
 
   @Test
   void basePropertyNames() {
     String[] keys = JsonEncoderBuilder.basePropertyNames(null);
-    assertThat(keys).isEqualTo(new String[]{"component", "env", "timestamp", "level", "logger", "message", "thread", "exceptionType", "exceptionMessage", "stackhash", "stacktrace"});
+    assertThat(keys).isEqualTo(new String[]{"component", "env", "timestamp", "level", "logger", "message", "thread", "exceptionType", "exceptionMessage", "stackhash", "stacktrace", "trace_id", "span_id"});
   }
 
   @Test
   void basePropertyNames_underscore() {
     String[] keys = JsonEncoderBuilder.basePropertyNames("underscore");
-    assertThat(keys).isEqualTo(new String[]{"component", "env", "timestamp", "level", "logger_name", "message", "thread", "exception_type", "exception_message", "exception_stackhash", "exception_stacktrace"});
+    assertThat(keys).isEqualTo(new String[]{"component", "env", "timestamp", "level", "logger_name", "message", "thread", "exception_type", "exception_message", "exception_stackhash", "exception_stacktrace", "trace_id", "span_id"});
   }
 
 
   @Test
   void basePropertyNames_camal() {
     String[] keys = JsonEncoderBuilder.basePropertyNames("camel");
-    assertThat(keys).isEqualTo(new String[]{"component", "env", "timestamp", "level", "loggerName", "message", "thread", "exceptionType", "exceptionMessage", "exceptionStackhash", "exceptionStacktrace"});
+    assertThat(keys).isEqualTo(new String[]{"component", "env", "timestamp", "level", "loggerName", "message", "thread", "exceptionType", "exceptionMessage", "exceptionStackhash", "exceptionStacktrace", "traceId", "spanId"});
   }
 }

--- a/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/JsonEncoderTraceTest.java
+++ b/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/JsonEncoderTraceTest.java
@@ -131,7 +131,6 @@ class JsonEncoderTraceTest {
     // trace_id/span_id/trace_flags from MDC should be excluded
     assertThat(json).doesNotContain("\"trace_id\"");
     assertThat(json).doesNotContain("\"span_id\"");
-    assertThat(json).doesNotContain("\"trace_flags\"");
     // other MDC entries should still appear
     assertThat(json).contains("\"customKey\":\"customValue\"");
   }

--- a/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/JsonEncoderTraceTest.java
+++ b/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/JsonEncoderTraceTest.java
@@ -1,0 +1,166 @@
+package io.avaje.simplelogger.encoder;
+
+import io.avaje.json.stream.JsonStream;
+import io.opentelemetry.api.trace.*;
+import io.opentelemetry.context.Scope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.slf4j.event.Level;
+
+import java.nio.charset.StandardCharsets;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JsonEncoderTraceTest {
+
+  static final String TRACE_ID = "0af7651916cd43dd8448eb211c80319c";
+  static final String SPAN_ID = "b7ad6b7169203331";
+
+  @AfterEach
+  void cleanup() {
+    MDC.clear();
+  }
+
+  private JsonEncoder buildEncoder(TraceContext traceContext) {
+    String[] propertyNames = JsonEncoderBuilder.basePropertyNames(null);
+    JsonStream json = JsonStream.builder().build();
+    DateTimeFormatter formatter = TimeZoneUtils.jsonFormatter(null, TimeZone.getDefault().toZoneId());
+    StackHasher stackHasher = new StackHasher(StackElementFilter.builder().allFilters().build());
+    return new JsonEncoder(propertyNames, json, null, null, stackHasher, formatter, true, new HashMap<>(), new ThrowableConverter(), traceContext);
+  }
+
+  private String encode(JsonEncoder encoder, String message, Throwable t) {
+    byte[] bytes = encoder.encode("test.Logger", Level.INFO, message, null, t);
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void noopTraceContext_traceFieldsAbsent() {
+    JsonEncoder encoder = buildEncoder(new NoopTraceContext());
+    String json = encode(encoder, "hello", null);
+
+    assertThat(json).doesNotContain("\"trace_id\"");
+    assertThat(json).doesNotContain("\"span_id\"");
+    assertThat(json).contains("\"message\":\"hello\"");
+  }
+
+  @Test
+  void otelTraceContext_withActiveSpan_traceFieldsPresent() {
+    JsonEncoder encoder = buildEncoder(new OtelTraceContext());
+
+    SpanContext spanContext = SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault());
+    Span span = Span.wrap(spanContext);
+
+    try (Scope ignored = span.makeCurrent()) {
+      String json = encode(encoder, "traced message", null);
+
+      assertThat(json).contains("\"trace_id\":\"" + TRACE_ID + "\"");
+      assertThat(json).contains("\"span_id\":\"" + SPAN_ID + "\"");
+      assertThat(json).contains("\"message\":\"traced message\"");
+    }
+  }
+
+  @Test
+  void otelTraceContext_noActiveSpan_traceFieldsAbsent() {
+    JsonEncoder encoder = buildEncoder(new OtelTraceContext());
+    String json = encode(encoder, "no trace", null);
+
+    assertThat(json).doesNotContain("\"trace_id\"");
+    assertThat(json).doesNotContain("\"span_id\"");
+  }
+
+  @Test
+  void traceFieldsCoexistWithException() {
+    JsonEncoder encoder = buildEncoder(new OtelTraceContext());
+    RuntimeException exception = new RuntimeException("test error");
+
+    SpanContext spanContext = SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault());
+    Span span = Span.wrap(spanContext);
+
+    try (Scope ignored = span.makeCurrent()) {
+      String json = encode(encoder, "error in span", exception);
+
+      assertThat(json).contains("\"trace_id\":\"" + TRACE_ID + "\"");
+      assertThat(json).contains("\"span_id\":\"" + SPAN_ID + "\"");
+      assertThat(json).contains("\"exceptionType\":\"java.lang.RuntimeException\"");
+      assertThat(json).contains("\"exceptionMessage\":\"test error\"");
+      assertThat(json).contains("\"stacktrace\":");
+    }
+  }
+
+  @Test
+  void propertyNameRemapping_traceFields() {
+    String[] keys = JsonEncoderBuilder.basePropertyNames(null);
+    String[] names = JsonEncoderBuilder.toPropertyNames(keys, "trace_id=traceIdentifier;span_id=spanIdentifier");
+
+    assertThat(names[11]).isEqualTo("traceIdentifier");
+    assertThat(names[12]).isEqualTo("spanIdentifier");
+  }
+
+  @Test
+  void initTraceContext_returnsOtelWhenOnClasspath() {
+    // OTEL API is on the test classpath, so builder should create OtelTraceContext
+    JsonEncoder encoder = new JsonEncoderBuilder().build();
+
+    // Verify by checking that with an active span, trace fields appear
+    SpanContext spanContext = SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault());
+    Span span = Span.wrap(spanContext);
+
+    try (Scope ignored = span.makeCurrent()) {
+      byte[] bytes = encoder.encode("test.Logger", Level.INFO, "check", null, null);
+      String json = new String(bytes, StandardCharsets.UTF_8);
+      assertThat(json).contains("\"trace_id\":\"" + TRACE_ID + "\"");
+    }
+  }
+
+  @Test
+  void mdcTraceKeys_excludedFromMdcSection() {
+    // Simulate what the OTEL agent does: inject trace_id, span_id, trace_flags into MDC
+    MDC.put("trace_id", TRACE_ID);
+    MDC.put("span_id", SPAN_ID);
+    MDC.put("trace_flags", "01");
+    MDC.put("customKey", "customValue");
+
+    JsonEncoder encoder = buildEncoder(new NoopTraceContext());
+    String json = encode(encoder, "mdc test", null);
+
+    // trace_id/span_id/trace_flags from MDC should be excluded
+    assertThat(json).doesNotContain("\"trace_id\"");
+    assertThat(json).doesNotContain("\"span_id\"");
+    assertThat(json).doesNotContain("\"trace_flags\"");
+    // other MDC entries should still appear
+    assertThat(json).contains("\"customKey\":\"customValue\"");
+  }
+
+  @Test
+  void otelActiveSpan_withMdcDuplicates_noDuplicateFields() {
+    // OTEL agent sets MDC AND we read from OTEL API — should only appear once
+    MDC.put("trace_id", TRACE_ID);
+    MDC.put("span_id", SPAN_ID);
+    MDC.put("trace_flags", "01");
+
+    JsonEncoder encoder = buildEncoder(new OtelTraceContext());
+
+    SpanContext spanContext = SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault());
+    Span span = Span.wrap(spanContext);
+
+    try (Scope ignored = span.makeCurrent()) {
+      String json = encode(encoder, "no dups", null);
+
+      // trace_id should appear exactly once (from OTEL API, not MDC)
+      int firstIdx = json.indexOf("\"trace_id\"");
+      int secondIdx = json.indexOf("\"trace_id\"", firstIdx + 1);
+      assertThat(firstIdx).isGreaterThan(-1);
+      assertThat(secondIdx).isEqualTo(-1);
+
+      int firstSpanIdx = json.indexOf("\"span_id\"");
+      int secondSpanIdx = json.indexOf("\"span_id\"", firstSpanIdx + 1);
+      assertThat(firstSpanIdx).isGreaterThan(-1);
+      assertThat(secondSpanIdx).isEqualTo(-1);
+    }
+  }
+}

--- a/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/NoopTraceContextTest.java
+++ b/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/NoopTraceContextTest.java
@@ -1,0 +1,20 @@
+package io.avaje.simplelogger.encoder;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NoopTraceContextTest {
+
+  final NoopTraceContext ctx = new NoopTraceContext();
+
+  @Test
+  void traceId_returnsNull() {
+    assertThat(ctx.traceId()).isNull();
+  }
+
+  @Test
+  void spanId_returnsNull() {
+    assertThat(ctx.spanId()).isNull();
+  }
+}

--- a/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/OtelTraceContextTest.java
+++ b/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/OtelTraceContextTest.java
@@ -1,0 +1,52 @@
+package io.avaje.simplelogger.encoder;
+
+import io.opentelemetry.api.trace.*;
+import io.opentelemetry.context.Scope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtelTraceContextTest {
+
+  final OtelTraceContext ctx = new OtelTraceContext();
+
+  @Test
+  void noActiveSpan_traceId_returnsNull() {
+    assertThat(ctx.traceId()).isNull();
+  }
+
+  @Test
+  void noActiveSpan_spanId_returnsNull() {
+    assertThat(ctx.spanId()).isNull();
+  }
+
+  @Test
+  void activeSpan_returnsTraceId() {
+    String expectedTraceId = "0af7651916cd43dd8448eb211c80319c";
+    String expectedSpanId = "b7ad6b7169203331";
+
+    SpanContext spanContext = SpanContext.create(expectedTraceId, expectedSpanId, TraceFlags.getSampled(), TraceState.getDefault());
+    Span span = Span.wrap(spanContext);
+
+    try (Scope ignored = span.makeCurrent()) {
+      assertThat(ctx.traceId()).isEqualTo(expectedTraceId);
+      assertThat(ctx.spanId()).isEqualTo(expectedSpanId);
+    }
+  }
+
+  @Test
+  void afterSpanEnds_returnsNull() {
+    String traceId = "0af7651916cd43dd8448eb211c80319c";
+    String spanId = "b7ad6b7169203331";
+
+    SpanContext spanContext = SpanContext.create(traceId, spanId, TraceFlags.getSampled(), TraceState.getDefault());
+    Span span = Span.wrap(spanContext);
+
+    try (Scope ignored = span.makeCurrent()) {
+      assertThat(ctx.traceId()).isNotNull();
+    }
+    // after scope closes, no active span
+    assertThat(ctx.traceId()).isNull();
+    assertThat(ctx.spanId()).isNull();
+  }
+}

--- a/avaje-simple-logger/src/main/java/io/avaje/simplelogger/graalvm/BuildInitialization.java
+++ b/avaje-simple-logger/src/main/java/io/avaje/simplelogger/graalvm/BuildInitialization.java
@@ -33,7 +33,12 @@ public class BuildInitialization implements Feature {
     RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.JsonWriter"));
     RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.SimpleLogger"));
     RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.PlainLogWriter"));
-
+    RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.NoopTraceContext"));
+    // register OtelTraceContext for build-time init when OTEL is on the classpath
+    Class<?> otelSpan = access.findClassByName("io.opentelemetry.api.trace.Span");
+    if (otelSpan != null) {
+      RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.simplelogger.encoder.OtelTraceContext"));
+    }
 
     RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.json.stream.core.JsonNames"));
     RuntimeClassInitialization.initializeAtBuildTime(access.findClassByName("io.avaje.json.stream.core.CoreJsonStream"));


### PR DESCRIPTION
For the case when using the OTEL javaagent, then the trace_id and span_id will be automatically put into the MDC. However, in the graalvm native image case we can't rely on that and instead need to get those directly from the OTEL API.

An alternative approach would be to create a separate OTEL integration module and service load that rather than use the reflection style initialisation. Looking to go with this first and see how it plays out (but there are no other trace/span API's planned so this approach seems ok and makes it simple for folks to use).