### PR TITLE
Add support for fluent addKeyValue() API for structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,31 @@ By default, the log format is JSON. Example:
 }
 ```
 
+### SLF4J 2 fluent key/value entries
+
+`addKeyValue()` entries from the SLF4J 2 fluent API are emitted as structured fields.
+
+```java
+logger.atInfo()
+  .addKeyValue("orderId", orderId)
+  .addKeyValue("processed", true)
+  .log("Order processed");
+```
+
+Example JSON output:
+
+```json
+{
+  "level":"INFO",
+  "logger":"com.example.OrderService",
+  "message":"Order processed",
+  "orderId":42,
+  "processed":true
+}
+```
+
+For `logger.format=plain`, fluent key/value entries are rendered as `key=value` pairs before the message.
+
 To override the json property names use `logger.propertyNames` delimited by `=` and `,` like:
 ```properties
 ## delimited by comma and equals
@@ -230,4 +255,3 @@ nameLevels.put("com.foo.bar", "info");
 ...
 LoggerContext.get().putAll(nameLevels);
 ```
-

--- a/avaje-simple-json-logger/pom.xml
+++ b/avaje-simple-json-logger/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.17</version>
+      <version>${slf4j.version}</version>
     </dependency>
 
     <dependency>
@@ -42,7 +42,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <type>test-jar</type>
-      <version>2.0.17</version>
+      <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/Bootstrap.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/Bootstrap.java
@@ -63,7 +63,7 @@ public final class Bootstrap {
       .timestampPattern(timestampPattern)
       .timeZone(timeZone)
       .build();
-    return new JsonWriter(jsonEncoder, target);
+    return new JsonLogWriter(jsonEncoder, target);
   }
 
   private static String property(Properties properties, String key) {

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonEncoder.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonEncoder.java
@@ -183,8 +183,15 @@ final class JsonEncoder {
     } else if (value instanceof byte[]) {
       writer.value((byte[]) value);
     } else {
-      writer.value(value.toString());
+      writer.value(safeToString(value));
     }
   }
 
+  private static String safeToString(Object value) {
+    try {
+      return String.valueOf(value);
+    } catch (RuntimeException e) {
+      return "<toString() failed: " + e.getClass().getName() + ">";
+    }
+  }
 }

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonEncoder.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonEncoder.java
@@ -162,14 +162,6 @@ final class JsonEncoder {
       return 4;
     } else if (value instanceof CharSequence) {
       return ((CharSequence) value).length();
-    } else if (value instanceof Boolean) {
-      return ((Boolean) value) ? 4 : 5;
-    } else if (value instanceof Integer || value instanceof Long || value instanceof Double
-      || value instanceof Float || value instanceof Short || value instanceof Byte
-      || value instanceof BigDecimal || value instanceof BigInteger) {
-      return String.valueOf(value).length();
-    } else if (value instanceof byte[]) {
-      return ((byte[]) value).length;
     } else {
       return 16;
     }
@@ -204,7 +196,7 @@ final class JsonEncoder {
     }
   }
 
-  private static String safeToString(Object value) {
+  static String safeToString(Object value) {
     try {
       return String.valueOf(value);
     } catch (RuntimeException e) {

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonEncoder.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonEncoder.java
@@ -1,14 +1,19 @@
 package io.avaje.simplelogger.encoder;
 
 import io.avaje.json.PropertyNames;
+import io.avaje.json.JsonWriter;
 import io.avaje.json.stream.JsonStream;
 import org.slf4j.MDC;
 import org.slf4j.event.Level;
+import org.slf4j.event.KeyValuePair;
 import org.slf4j.helpers.MessageFormatter;
 
 import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Map;
 
 final class JsonEncoder {
@@ -52,7 +57,7 @@ final class JsonEncoder {
       .sum();
   }
 
-  byte[] encode(String loggerName, Level level, String messagePattern, Object[] arguments, Throwable t) {
+  byte[] encode(String loggerName, Level level, String messagePattern, Object[] arguments, Throwable t, List<KeyValuePair> keyValuePairs) {
     final String stackTraceBody = t == null ? "" : throwableConverter.convert(t);
     final int extra = stackTraceBody.isEmpty() ? 0 : 20 + stackTraceBody.length();
 
@@ -62,7 +67,7 @@ final class JsonEncoder {
     }
 
     final var threadName = Thread.currentThread().getName();
-    final int bufferSize = 100 + extra + fieldExtra + message.length() + threadName.length() + loggerName.length();
+    final int bufferSize = 100 + extra + fieldExtra + keyValueExtra(keyValuePairs) + message.length() + threadName.length() + loggerName.length();
     final var outputStream = new ByteArrayOutputStream(bufferSize);
 
     try (var writer = json.writer(outputStream)) {
@@ -108,6 +113,15 @@ final class JsonEncoder {
         writer.name(10);
         writer.value(stackTraceBody);
       }
+      if (keyValuePairs != null) {
+        for (KeyValuePair keyValuePair : keyValuePairs) {
+          if (keyValuePair == null) {
+            continue;
+          }
+          writer.name(String.valueOf(keyValuePair.key));
+          writeKeyValue(writer, keyValuePair.value);
+        }
+      }
       customFieldsMap.forEach((k, v) -> {
         writer.name(k);
         writer.rawValue(v);
@@ -125,6 +139,52 @@ final class JsonEncoder {
       writer.writeNewLine();
     }
     return outputStream.toByteArray();
+  }
+
+  private static int keyValueExtra(List<KeyValuePair> keyValuePairs) {
+    if (keyValuePairs == null || keyValuePairs.isEmpty()) {
+      return 0;
+    }
+    int extra = 0;
+    for (KeyValuePair keyValuePair : keyValuePairs) {
+      if (keyValuePair == null) {
+        continue;
+      }
+      extra += String.valueOf(keyValuePair.key).length();
+      extra += String.valueOf(keyValuePair.value).length();
+      extra += 6;
+    }
+    return extra;
+  }
+
+  private static void writeKeyValue(JsonWriter writer, Object value) {
+    if (value == null) {
+      writer.nullValue();
+    } else if (value instanceof CharSequence) {
+      writer.value(value.toString());
+    } else if (value instanceof Boolean) {
+      writer.value((Boolean) value);
+    } else if (value instanceof Integer) {
+      writer.value((Integer) value);
+    } else if (value instanceof Long) {
+      writer.value((Long) value);
+    } else if (value instanceof Double) {
+      writer.value((Double) value);
+    } else if (value instanceof Float) {
+      writer.value(((Float) value).doubleValue());
+    } else if (value instanceof Short) {
+      writer.value(((Short) value).intValue());
+    } else if (value instanceof Byte) {
+      writer.value(((Byte) value).intValue());
+    } else if (value instanceof BigDecimal) {
+      writer.value((BigDecimal) value);
+    } else if (value instanceof BigInteger) {
+      writer.value((BigInteger) value);
+    } else if (value instanceof byte[]) {
+      writer.value((byte[]) value);
+    } else {
+      writer.value(value.toString());
+    }
   }
 
 }

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonEncoder.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonEncoder.java
@@ -150,13 +150,30 @@ final class JsonEncoder {
       if (keyValuePair == null) {
         continue;
       }
-      extra += String.valueOf(keyValuePair.key).length();
-      extra += String.valueOf(keyValuePair.value).length();
+      extra += keyValuePair.key == null ? 4 : keyValuePair.key.length();
+      extra += estimatedValueLength(keyValuePair.value);
       extra += 6;
     }
     return extra;
   }
 
+  private static int estimatedValueLength(Object value) {
+    if (value == null) {
+      return 4;
+    } else if (value instanceof CharSequence) {
+      return ((CharSequence) value).length();
+    } else if (value instanceof Boolean) {
+      return ((Boolean) value) ? 4 : 5;
+    } else if (value instanceof Integer || value instanceof Long || value instanceof Double
+      || value instanceof Float || value instanceof Short || value instanceof Byte
+      || value instanceof BigDecimal || value instanceof BigInteger) {
+      return String.valueOf(value).length();
+    } else if (value instanceof byte[]) {
+      return ((byte[]) value).length;
+    } else {
+      return 16;
+    }
+  }
   private static void writeKeyValue(JsonWriter writer, Object value) {
     if (value == null) {
       writer.nullValue();

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonLogWriter.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonLogWriter.java
@@ -8,12 +8,12 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.List;
 
-final class JsonWriter implements LogWriter {
+final class JsonLogWriter implements LogWriter {
 
   private final JsonEncoder encoder;
   private final PrintStream out;
 
-  JsonWriter(JsonEncoder encoder, PrintStream out) {
+  JsonLogWriter(JsonEncoder encoder, PrintStream out) {
     this.encoder = encoder;
     this.out = out;
   }

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonWriter.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonWriter.java
@@ -1,10 +1,12 @@
 package io.avaje.simplelogger.encoder;
 
 import org.slf4j.event.Level;
+import org.slf4j.event.KeyValuePair;
 import org.slf4j.helpers.Reporter;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.List;
 
 final class JsonWriter implements LogWriter {
 
@@ -17,9 +19,9 @@ final class JsonWriter implements LogWriter {
   }
 
   @Override
-  public void log(String loggerName, Level level, String messagePattern, Object[] arguments, Throwable t) {
+  public void log(String loggerName, Level level, String messagePattern, Object[] arguments, Throwable t, List<KeyValuePair> keyValuePairs) {
     try {
-      out.write(encoder.encode(loggerName, level, messagePattern, arguments, t));
+      out.write(encoder.encode(loggerName, level, messagePattern, arguments, t, keyValuePairs));
     } catch (IOException e) {
       Reporter.error("Failed to write to log", e);
     }

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/LogWriter.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/LogWriter.java
@@ -1,8 +1,12 @@
 package io.avaje.simplelogger.encoder;
 
 import org.slf4j.event.Level;
+import org.slf4j.event.KeyValuePair;
+
+import java.util.List;
 
 interface LogWriter {
 
-  void log(String loggerName, Level level, String messagePattern, Object[] arguments, Throwable t);
+  void log(String loggerName, Level level, String messagePattern, Object[] arguments, Throwable t, List<KeyValuePair> keyValuePairs);
+
 }

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/PlainLogWriter.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/PlainLogWriter.java
@@ -10,6 +10,8 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+import static io.avaje.simplelogger.encoder.JsonEncoder.safeToString;
+
 final class PlainLogWriter implements LogWriter {
 
   private static final char SP = ' ';
@@ -54,7 +56,7 @@ final class PlainLogWriter implements LogWriter {
       }
       content.append(keyValuePair.key)
         .append('=')
-        .append(keyValuePair.value)
+        .append(safeToString(keyValuePair.value))
         .append(SP);
     }
     if (message != null) {

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/PlainLogWriter.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/PlainLogWriter.java
@@ -1,12 +1,14 @@
 package io.avaje.simplelogger.encoder;
 
 import org.slf4j.event.Level;
+import org.slf4j.event.KeyValuePair;
 import org.slf4j.helpers.MessageFormatter;
 import org.slf4j.spi.LocationAwareLogger;
 
 import java.io.PrintStream;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 final class PlainLogWriter implements LogWriter {
 
@@ -23,7 +25,7 @@ final class PlainLogWriter implements LogWriter {
   }
 
   @Override
-  public void log(String loggerName, Level level, String messagePattern, Object[] arguments, Throwable t) {
+  public void log(String loggerName, Level level, String messagePattern, Object[] arguments, Throwable t, List<KeyValuePair> keyValuePairs) {
     StringBuilder buf = new StringBuilder(200);
     buf.append(formattedTimestamp());
     buf.append(SP);
@@ -36,8 +38,29 @@ final class PlainLogWriter implements LogWriter {
     buf.append(SP);
 
     buf.append(loggerName).append(" - ");
-    buf.append(MessageFormatter.basicArrayFormat(messagePattern, arguments));
+    final String message = MessageFormatter.basicArrayFormat(messagePattern, arguments);
+    buf.append(withKeyValues(message, keyValuePairs));
     write(buf, t);
+  }
+
+  private String withKeyValues(String message, List<KeyValuePair> keyValuePairs) {
+    if (keyValuePairs == null || keyValuePairs.isEmpty()) {
+      return message;
+    }
+    final StringBuilder content = new StringBuilder(40 + (message == null ? 0 : message.length()));
+    for (KeyValuePair keyValuePair : keyValuePairs) {
+      if (keyValuePair == null) {
+        continue;
+      }
+      content.append(keyValuePair.key)
+        .append('=')
+        .append(keyValuePair.value)
+        .append(SP);
+    }
+    if (message != null) {
+      content.append(message);
+    }
+    return content.toString();
   }
 
   private void write(StringBuilder buf, Throwable t) {

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/SimpleLogger.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/SimpleLogger.java
@@ -2,11 +2,13 @@ package io.avaje.simplelogger.encoder;
 
 import org.slf4j.Marker;
 import org.slf4j.event.Level;
+import org.slf4j.event.LoggingEvent;
 import org.slf4j.helpers.LegacyAbstractLogger;
+import org.slf4j.spi.LoggingEventAware;
 
 import static org.slf4j.spi.LocationAwareLogger.*;
 
-final class SimpleLogger extends LegacyAbstractLogger {
+final class SimpleLogger extends LegacyAbstractLogger implements LoggingEventAware {
 
   private final LogWriter writer;
   private final String shortName;
@@ -66,8 +68,21 @@ final class SimpleLogger extends LegacyAbstractLogger {
     logNormalized(level, messagePattern, arguments, throwable);
   }
 
+  @Override
+  public void log(LoggingEvent event) {
+    final Level eventLevel = event.getLevel();
+    if (eventLevel == null || !isEnabled(eventLevel.toInt())) {
+      return;
+    }
+    writer.log(shortName, eventLevel, event.getMessage(), event.getArgumentArray(), event.getThrowable(), event.getKeyValuePairs());
+  }
+
+  private boolean isEnabled(int eventLevel) {
+    return eventLevel >= level;
+  }
+
   private void logNormalized(Level level, String messagePattern, Object[] arguments, Throwable t) {
-    writer.log(shortName, level, messagePattern, arguments, t);
+    writer.log(shortName, level, messagePattern, arguments, t, null);
   }
 
 //    public void log(LoggingEvent event) {

--- a/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/FluentKeyValueTest.java
+++ b/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/FluentKeyValueTest.java
@@ -1,0 +1,143 @@
+package io.avaje.simplelogger.encoder;
+
+import io.avaje.json.stream.JsonStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.slf4j.event.KeyValuePair;
+import org.slf4j.event.Level;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.slf4j.spi.LocationAwareLogger.INFO_INT;
+
+class FluentKeyValueTest {
+
+  @AfterEach
+  void cleanup() {
+    MDC.clear();
+  }
+
+  @Test
+  void simpleLoggerFluent_addKeyValue_passesStructuredPairsToWriter() {
+    CapturingLogWriter writer = new CapturingLogWriter();
+    SimpleLogger logger = new SimpleLogger(writer, "test.logger.Name", "Name", INFO_INT);
+
+    logger.atInfo()
+      .addKeyValue("orderId", 42)
+      .addKeyValue("processed", true)
+      .log("hello {}", "world");
+
+    assertThat(writer.level).isEqualTo(Level.INFO);
+    assertThat(writer.loggerName).isEqualTo("Name");
+    assertThat(writer.messagePattern).isEqualTo("hello {}");
+    assertThat(writer.arguments).containsExactly("world");
+    assertThat(writer.throwable).isNull();
+    assertThat(writer.keyValuePairs).hasSize(2);
+    assertThat(writer.keyValuePairs.get(0).key).isEqualTo("orderId");
+    assertThat(writer.keyValuePairs.get(0).value).isEqualTo(42);
+    assertThat(writer.keyValuePairs.get(1).key).isEqualTo("processed");
+    assertThat(writer.keyValuePairs.get(1).value).isEqualTo(true);
+  }
+
+  @Test
+  void jsonEncoder_addKeyValue_writesStructuredFields() {
+    JsonEncoder encoder = buildEncoder();
+    List<KeyValuePair> keyValuePairs = List.of(
+      new KeyValuePair("orderId", 42),
+      new KeyValuePair("processed", true),
+      new KeyValuePair("note", "done"),
+      new KeyValuePair("amount", 12.5d),
+      new KeyValuePair("valueObject", new NamedValue("custom"))
+    );
+
+    String json = new String(
+      encoder.encode("test.Logger", Level.INFO, "hello {}", new Object[]{"world"}, null, keyValuePairs),
+      StandardCharsets.UTF_8
+    );
+
+    assertThat(json).contains("\"message\":\"hello world\"");
+    assertThat(json).contains("\"orderId\":42");
+    assertThat(json).contains("\"processed\":true");
+    assertThat(json).contains("\"note\":\"done\"");
+    assertThat(json).contains("\"amount\":12.5");
+    assertThat(json).contains("\"valueObject\":\"custom\"");
+  }
+
+  @Test
+  void plainLogWriter_addKeyValue_prefixesMessage() {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    PlainLogWriter writer = new PlainLogWriter(new PrintStream(output), DateTimeFormatter.ISO_OFFSET_DATE_TIME, false);
+
+    writer.log(
+      "test.Logger",
+      Level.INFO,
+      "hello {}",
+      new Object[]{"world"},
+      null,
+      List.of(new KeyValuePair("orderId", 42), new KeyValuePair("processed", true))
+    );
+
+    String logLine = new String(output.toByteArray(), StandardCharsets.UTF_8);
+    assertThat(logLine).contains("orderId=42 processed=true hello world");
+  }
+
+  private JsonEncoder buildEncoder() {
+    String[] propertyNames = JsonEncoderBuilder.basePropertyNames(null);
+    JsonStream json = JsonStream.builder().build();
+    DateTimeFormatter formatter = TimeZoneUtils.jsonFormatter(null, TimeZone.getDefault().toZoneId());
+    StackHasher stackHasher = new StackHasher(StackElementFilter.builder().allFilters().build());
+    return new JsonEncoder(
+      propertyNames,
+      json,
+      null,
+      null,
+      stackHasher,
+      formatter,
+      true,
+      new HashMap<>(),
+      new ThrowableConverter(),
+      new NoopTraceContext()
+    );
+  }
+
+  private static final class CapturingLogWriter implements LogWriter {
+    private String loggerName;
+    private Level level;
+    private String messagePattern;
+    private Object[] arguments;
+    private Throwable throwable;
+    private List<KeyValuePair> keyValuePairs;
+
+    @Override
+    public void log(String loggerName, Level level, String messagePattern, Object[] arguments, Throwable t, List<KeyValuePair> keyValuePairs) {
+      this.loggerName = loggerName;
+      this.level = level;
+      this.messagePattern = messagePattern;
+      this.arguments = arguments == null ? null : arguments.clone();
+      this.throwable = t;
+      this.keyValuePairs = keyValuePairs == null ? null : new ArrayList<>(keyValuePairs);
+    }
+  }
+
+  private static final class NamedValue {
+    private final String value;
+
+    private NamedValue(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+  }
+}

--- a/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/JsonEncoderTraceTest.java
+++ b/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/JsonEncoderTraceTest.java
@@ -34,7 +34,7 @@ class JsonEncoderTraceTest {
   }
 
   private String encode(JsonEncoder encoder, String message, Throwable t) {
-    byte[] bytes = encoder.encode("test.Logger", Level.INFO, message, null, t);
+    byte[] bytes = encoder.encode("test.Logger", Level.INFO, message, null, t, null);
     return new String(bytes, StandardCharsets.UTF_8);
   }
 
@@ -111,7 +111,7 @@ class JsonEncoderTraceTest {
     Span span = Span.wrap(spanContext);
 
     try (Scope ignored = span.makeCurrent()) {
-      byte[] bytes = encoder.encode("test.Logger", Level.INFO, "check", null, null);
+      byte[] bytes = encoder.encode("test.Logger", Level.INFO, "check", null, null, null);
       String json = new String(bytes, StandardCharsets.UTF_8);
       assertThat(json).contains("\"trace_id\":\"" + TRACE_ID + "\"");
     }

--- a/avaje-simple-logger/pom.xml
+++ b/avaje-simple-logger/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.17</version>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>io.avaje</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,10 @@
   <version>1.5-RC1</version>
   <packaging>pom</packaging>
 
+  <properties>
+    <slf4j.version>2.0.17</slf4j.version>
+  </properties>
+
   <modules>
     <module>avaje-simple-json-logger</module>
     <module>avaje-simple-logger</module>


### PR DESCRIPTION
### SLF4J 2 fluent key/value entries

`addKeyValue()` entries from the SLF4J 2 fluent API are emitted as structured fields.

```java
logger.atInfo()
  .addKeyValue("orderId", orderId)
  .addKeyValue("processed", true)
  .log("Order processed");
```

Example JSON output:

```json
{
  "level":"INFO",
  "logger":"com.example.OrderService",
  "message":"Order processed",
  "orderId":42,
  "processed":true
}
```

For `logger.format=plain`, fluent key/value entries are rendered as `key=value` pairs before the message.