### PR TITLE
Remove k8s auto naming of COMPONENT (to allow not having it in k8s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,6 @@ logger.propertyNames=logger=loggerName
 A `component` key value is added if:
 - There is a `logger.component` property set in `avaje-logger.properties`
 - There is a `COMPONENT` environment variable set
-- K8s is detected, it will be derived from the `HOSTNAME` environment variable
 
 This key value is expected to represent the application component that is the source of
 the logs.

--- a/avaje-simple-json-logger/pom.xml
+++ b/avaje-simple-json-logger/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-simple-logger-parent</artifactId>
-    <version>1.5-RC1</version>
+    <version>1.5</version>
   </parent>
 
   <artifactId>avaje-simple-json-logger</artifactId>

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/Eval.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/Eval.java
@@ -11,29 +11,7 @@ final class Eval {
    * For K8s this derives the component name from the HOSTNAME.
    */
   static String defaultComponent() {
-    String component = System.getenv("COMPONENT");
-    if (component != null) {
-      return component;
-    }
-    if (System.getenv("KUBERNETES_PORT") != null) {
-      // in k8s we can default off the hostname
-      return k8sComponent(System.getenv("HOSTNAME"));
-    }
-    return null;
-  }
-
-  static String k8sComponent(String hostname) {
-    if (hostname == null) {
-      return null;
-    }
-    int p0 = hostname.lastIndexOf('-');
-    if (p0 > 1) {
-      int p1 = hostname.lastIndexOf('-', p0 - 1);
-      if (p1 > 0) {
-        return hostname.substring(0, p1);
-      }
-    }
-    return null;
+    return System.getenv("COMPONENT");
   }
 
   /**

--- a/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/EvalTest.java
+++ b/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/EvalTest.java
@@ -7,11 +7,6 @@ import static org.junit.jupiter.api.Assertions.*;
 class EvalTest {
 
   @Test
-  void k8sComponent() {
-    assertEquals("my-component", Eval.k8sComponent("my-component-part0-part1"));
-  }
-
-  @Test
   void eval() {
     String expected = System.getProperty("user.home");
     assertEquals(expected, Eval.eval("${user.home:someDefault}"));

--- a/avaje-simple-logger/pom.xml
+++ b/avaje-simple-logger/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-simple-logger-parent</artifactId>
-    <version>1.5-RC1</version>
+    <version>1.5</version>
   </parent>
 
   <artifactId>avaje-simple-logger</artifactId>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-simple-json-logger</artifactId>
-      <version>1.5-RC1</version>
+      <version>1.5</version>
     </dependency>
     <dependency>
       <groupId>io.avaje</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <groupId>io.avaje</groupId>
   <artifactId>avaje-simple-logger-parent</artifactId>
   <name>avaje-simple-logger-parent</name>
-  <version>1.5-RC1</version>
+  <version>1.5</version>
   <packaging>pom</packaging>
 
   <properties>


### PR DESCRIPTION
Migrate to explicitly registering it via avaje-logger.properties

`logger.component=foo`

The reason to remove this feature, is that it means that in K8s we
are always going to end up with a component element even when we
don't want to. There are cases when we don't want to because it
takes space and hence costs money.

We can always more explicitly specify it and that seems good.


## This is a behaviour change, will include this in a major version bump to 2.x