### PR TITLE
Change the default naming to underscore

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ By default, the log format is JSON. Example:
   "env":"dev",
   "timestamp":"2025-07-14T13:44:44.230959+12:00",
   "level":"TRACE",
-  "logger":"io.avaje.config",
+  "logger_name":"io.avaje.config",
   "message":"load from [resource:application-test.properties]",
   "thread":"main"
 }
@@ -173,15 +173,60 @@ Example JSON output:
 
 For `logger.format=plain`, fluent key/value entries are rendered as `key=value` pairs before the message.
 
-To override the json property names use `logger.propertyNames` delimited by `=` and `,` like:
+### JSON Field Naming Conventions
+
+avaje-simple-logger supports three field naming conventions via the `logger.naming` property:
+
+| Convention | Description | Examples |
+|-----------|-------------|----------|
+| **underscore** (DEFAULT) | All fields use underscore format | `logger_name`, `exception_type`, `exception_message`, `exception_stacktrace` |
+| **camel** | All fields use camelCase format | `loggerName`, `exceptionType`, `exceptionMessage`, `exceptionStacktrace` |
+| **legacy** | Mixed format for backwards compatibility | `logger`, `exceptionType`, `exceptionMessage`, `stacktrace` |
+
+Configure the naming convention in your properties file:
+
+```properties
+# Underscore format (default, no need to specify)
+logger.naming=underscore
+
+# OR use camelCase
+logger.naming=camel
+
+# OR use legacy format
+logger.naming=legacy
+```
+
+Example with underscore (default):
+```json
+{
+  "logger_name":"io.avaje.config",
+  "exception_type":"java.lang.RuntimeException",
+  "exception_message":"Configuration error",
+  "exception_stacktrace":"..."
+}
+```
+
+Example with camelCase:
+```json
+{
+  "loggerName":"io.avaje.config",
+  "exceptionType":"java.lang.RuntimeException",
+  "exceptionMessage":"Configuration error",
+  "exceptionStacktrace":"..."
+}
+```
+
+### Overriding Individual Property Names
+
+To override specific json property names use `logger.propertyNames` delimited by `=` and `,` like:
 ```properties
 ## delimited by comma and equals
-logger.propertyNames=logger=loggerName,env=environment,timestamp=@timestamp
+logger.propertyNames=logger_name=loggerName,env=environment,timestamp=@timestamp
 ```
 
 Example overriding a single property:
 ```properties
-logger.propertyNames=logger=loggerName
+logger.propertyNames=logger_name=customLoggerName
 ```
 
 #### component

--- a/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonEncoderBuilder.java
+++ b/avaje-simple-json-logger/src/main/java/io/avaje/simplelogger/encoder/JsonEncoderBuilder.java
@@ -126,12 +126,13 @@ final class JsonEncoderBuilder {
   }
 
   static String[] basePropertyNames(String naming) {
-    if ("underscore".equals(naming)) {
-      return new String[]{"component", "env", "timestamp", "level", "logger_name", "message", "thread", "exception_type", "exception_message", "exception_stackhash", "exception_stacktrace", "trace_id", "span_id"};
-    } else if ("camel".equals(naming)) {
+    if ("camel".equals(naming)) {
       return new String[]{"component", "env", "timestamp", "level", "loggerName", "message", "thread", "exceptionType", "exceptionMessage", "exceptionStackhash", "exceptionStacktrace", "traceId", "spanId"};
-    } else {
+    } else if ("legacy".equals(naming)) {
       return new String[]{"component", "env", "timestamp", "level", "logger", "message", "thread", "exceptionType", "exceptionMessage", "stackhash", "stacktrace", "trace_id", "span_id"};
+    } else {
+      // underscore naming is now default
+      return new String[]{"component", "env", "timestamp", "level", "logger_name", "message", "thread", "exception_type", "exception_message", "exception_stackhash", "exception_stacktrace", "trace_id", "span_id"};
     }
   }
 

--- a/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/JsonEncoderBuilderTest.java
+++ b/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/JsonEncoderBuilderTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JsonEncoderBuilderTest {
 
-  String[] baseKeys = {"component", "env", "timestamp", "level", "logger", "message", "thread", "exceptionType", "exceptionMessage", "stackhash", "stacktrace", "trace_id", "span_id"};
+  String[] baseKeys = {"component", "env", "timestamp", "level", "logger_name", "message", "thread", "exception_type", "exception_message", "exception_stackhash", "exception_stacktrace", "trace_id", "span_id"};
 
   @Test
   void toPropertyNames_when_null() {
@@ -20,21 +20,21 @@ class JsonEncoderBuilderTest {
   @Test
   void toPropertyNames_several() {
     String[] originalKeys = JsonEncoderBuilder.basePropertyNames(null);
-    String[] names = JsonEncoderBuilder.toPropertyNames(originalKeys,"component = c; env=e,thread=_foo ,exceptionType=exType ");
-    assertThat(names).isEqualTo(new String[]{"c", "e", "timestamp", "level", "logger", "message", "_foo", "exType", "exceptionMessage", "stackhash", "stacktrace", "trace_id", "span_id"});
+    String[] names = JsonEncoderBuilder.toPropertyNames(originalKeys,"component = c; env=e,thread=_foo ,exception_type=exType ");
+    assertThat(names).isEqualTo(new String[]{"c", "e", "timestamp", "level", "logger_name", "message", "_foo", "exType", "exception_message", "exception_stackhash", "exception_stacktrace", "trace_id", "span_id"});
   }
 
   @Test
   void toPropertyNames_onlyOne() {
     String[] originalKeys = JsonEncoderBuilder.basePropertyNames(null);
-    String[] names = JsonEncoderBuilder.toPropertyNames(originalKeys, "logger=loggerName");
-    assertThat(names).isEqualTo(new String[]{"component", "env", "timestamp", "level", "loggerName", "message", "thread", "exceptionType", "exceptionMessage", "stackhash", "stacktrace", "trace_id", "span_id"});
+    String[] names = JsonEncoderBuilder.toPropertyNames(originalKeys, "logger_name=customLoggerName");
+    assertThat(names).isEqualTo(new String[]{"component", "env", "timestamp", "level", "customLoggerName", "message", "thread", "exception_type", "exception_message", "exception_stackhash", "exception_stacktrace", "trace_id", "span_id"});
   }
 
   @Test
   void basePropertyNames() {
     String[] keys = JsonEncoderBuilder.basePropertyNames(null);
-    assertThat(keys).isEqualTo(new String[]{"component", "env", "timestamp", "level", "logger", "message", "thread", "exceptionType", "exceptionMessage", "stackhash", "stacktrace", "trace_id", "span_id"});
+    assertThat(keys).isEqualTo(new String[]{"component", "env", "timestamp", "level", "logger_name", "message", "thread", "exception_type", "exception_message", "exception_stackhash", "exception_stacktrace", "trace_id", "span_id"});
   }
 
   @Test
@@ -43,9 +43,14 @@ class JsonEncoderBuilderTest {
     assertThat(keys).isEqualTo(new String[]{"component", "env", "timestamp", "level", "logger_name", "message", "thread", "exception_type", "exception_message", "exception_stackhash", "exception_stacktrace", "trace_id", "span_id"});
   }
 
+  @Test
+  void basePropertyNames_legacy() {
+    String[] keys = JsonEncoderBuilder.basePropertyNames("legacy");
+    assertThat(keys).isEqualTo(new String[]{"component", "env", "timestamp", "level", "logger", "message", "thread", "exceptionType", "exceptionMessage", "stackhash", "stacktrace", "trace_id", "span_id"});
+  }
 
   @Test
-  void basePropertyNames_camal() {
+  void basePropertyNames_camel() {
     String[] keys = JsonEncoderBuilder.basePropertyNames("camel");
     assertThat(keys).isEqualTo(new String[]{"component", "env", "timestamp", "level", "loggerName", "message", "thread", "exceptionType", "exceptionMessage", "exceptionStackhash", "exceptionStacktrace", "traceId", "spanId"});
   }

--- a/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/JsonEncoderTraceTest.java
+++ b/avaje-simple-json-logger/src/test/java/io/avaje/simplelogger/encoder/JsonEncoderTraceTest.java
@@ -86,9 +86,9 @@ class JsonEncoderTraceTest {
 
       assertThat(json).contains("\"trace_id\":\"" + TRACE_ID + "\"");
       assertThat(json).contains("\"span_id\":\"" + SPAN_ID + "\"");
-      assertThat(json).contains("\"exceptionType\":\"java.lang.RuntimeException\"");
-      assertThat(json).contains("\"exceptionMessage\":\"test error\"");
-      assertThat(json).contains("\"stacktrace\":");
+      assertThat(json).contains("\"exception_type\":\"java.lang.RuntimeException\"");
+      assertThat(json).contains("\"exception_message\":\"test error\"");
+      assertThat(json).contains("\"exception_stacktrace\":");
     }
   }
 

--- a/docs/guides/add-avaje-simple-logger-to-maven-project.md
+++ b/docs/guides/add-avaje-simple-logger-to-maven-project.md
@@ -61,6 +61,9 @@ logger.defaultLogLevel=warn
 # Output format: json (default) or plain
 logger.format=json
 
+# JSON field naming convention: underscore (default), camel, or legacy
+logger.naming=underscore
+
 # Logger name formatting: full, short, or character limit (e.g., 100)
 logger.nameTargetLength=50
 
@@ -495,12 +498,61 @@ Timestamp format in logs.
 logger.timestampPattern=ISO_OFFSET_DATE_TIME
 ```
 
+#### logger.naming
+JSON field naming convention (when using `logger.format=json`).
+
+**Values:** `underscore` (default), `camel`, `legacy`
+
+```properties
+# Underscore format (default, recommended for new projects)
+# Fields: logger_name, exception_type, exception_message, exception_stacktrace
+logger.naming=underscore
+
+# CamelCase format
+# Fields: loggerName, exceptionType, exceptionMessage, exceptionStacktrace
+logger.naming=camel
+
+# Legacy format (for backwards compatibility)
+# Fields: logger, exceptionType, exceptionMessage, stacktrace
+logger.naming=legacy
+```
+
+Example JSON output with underscore (default):
+```json
+{
+  "logger_name":"io.avaje.config",
+  "exception_type":"java.lang.RuntimeException",
+  "exception_message":"Configuration error"
+}
+```
+
+Example JSON output with camelCase:
+```json
+{
+  "loggerName":"io.avaje.config",
+  "exceptionType":"java.lang.RuntimeException",
+  "exceptionMessage":"Configuration error"
+}
+```
+
+#### logger.propertyNames
+Override specific JSON property names.
+
+```properties
+# Override individual property names (comma and equals delimited)
+logger.propertyNames=logger_name=app_logger,env=application_env,timestamp=@timestamp
+
+# Override a single property
+logger.propertyNames=logger_name=loggerName
+```
+
 ### Complete Example Configuration
 
 ```properties
 # Basic configuration
 logger.defaultLogLevel=warn
 logger.format=json
+logger.naming=underscore
 logger.nameTargetLength=full
 logger.timezone=UTC
 


### PR DESCRIPTION
The legacy naming wasn't consistent enough, and now it's best to use underscore or camel, and going with underscore as the default (bit of a 50/50 call but seems more widely used).

### This is a behaviour change, include in a 2.x version